### PR TITLE
Catch json_encode errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 index.php
+
+# JetBrains IDEs
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: php
 php:
     - "5.5"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Autoprefixer PHP [![Build Status](https://travis-ci.org/ulkoalex/autoprefixer-php.svg?branch=master)](https://travis-ci.org/vladkens/autoprefixer-php)
+# Autoprefixer PHP
 
 [Autoprefixer](https://github.com/ai/autoprefixer) is a tool
 to parse CSS and add vendor prefixes to CSS rules using values

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Autoprefixer PHP [![Build Status](https://travis-ci.org/vladkens/autoprefixer-php.svg?branch=master)](https://travis-ci.org/vladkens/autoprefixer-php)
+# Autoprefixer PHP [![Build Status](https://travis-ci.org/ulkoalex/autoprefixer-php.svg?branch=master)](https://travis-ci.org/vladkens/autoprefixer-php)
 
 [Autoprefixer](https://github.com/ai/autoprefixer) is a tool
 to parse CSS and add vendor prefixes to CSS rules using values

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ $autoprefixer->compile($css_one, 'last 1 version');
 $autoprefixer->update();
 ```
 
+## Configuration
+
+You can set the path to the Autoprefixer error log using the const `AF_LOG_PATH`. By default,
+the log will be written to the file located at `sys_get_temp_dir() . '/autoprefixer.error.log'`.
+
 ## Speed
 On my Intel i5-3210M 2.5GHz and HDD 5200 RPM GitHub styles compiled in 390 ms.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ $autoprefixer->update();
 You can set the path to the Autoprefixer error log using the const `AF_LOG_PATH`. By default,
 the log will be written to the file located at `sys_get_temp_dir() . '/autoprefixer.error.log'`.
 
+The path to the Node.js can be set using the const `NODE_PATH` or the `node` will be used in the `proc_open`.
+
 ## Speed
 On my Intel i5-3210M 2.5GHz and HDD 5200 RPM GitHub styles compiled in 390 ms.
 

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -44,14 +44,16 @@ class Autoprefixer
 	 */
 	public function compile($css, $browsers = null)
 	{
-        if ($return_string = !is_array($css)) {
+		$return_string = !is_array($css);
+
+		if ($return_string) {
 			$css = array($css);
 		}
 
 		$data_string = json_encode(array(
 			'css'      => $css,
-            'browsers' => !is_null($browsers) ? $browsers : $this->browsers)
-        );
+			'browsers' => !is_null($browsers) ? $browsers : $this->browsers
+		));
 
 		if ($data_string === false || $data_string === null) {
 			$error_message = 'Failed to json_encode: ';
@@ -70,6 +72,10 @@ class Autoprefixer
 		if ($nodejs === false) {
 			throw new RuntimeException('Could not reach node runtime');
 		}
+
+		// Make stdin/stdout non-blocking
+		// stream_set_blocking($pipes[0], 0);
+		// stream_set_blocking($pipes[1], 0);
 
 		$written = $this->fwrite_stream($pipes[0], $data_string);
 		fclose($pipes[0]);

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -72,7 +72,7 @@ class Autoprefixer
             throw new AutoprefixerException("Error log file $error_log_file_path isn't writable");
         }
 
-		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
+		$nodejs = proc_open((defined('NODE_PATH') ? NODE_PATH : 'node') . ' ' . __DIR__ . '/vendor/wrap.js',
 			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file_path, 'a')),
 			$pipes
 		);

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -65,10 +65,18 @@ class Autoprefixer
 			throw new AutoprefixerException($error_message);
 		}
 
+        // by default, use OS temp dir
+        $error_log_file_path = defined('AF_LOG_PATH') ? AF_LOG_PATH : (sys_get_temp_dir() . '/autoprefixer.error.log');
+
+        if (!is_writable($error_log_file_path)){
+            throw new AutoprefixerException("Error log file $error_log_file_path isn't writable");
+        }
+
 		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
-			array(array('pipe', 'r'), array('pipe', 'w'), array('file', '/tmp/autoprefixer.error.log', 'a')),
+			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file_path, 'a')),
 			$pipes
 		);
+
 		if ($nodejs === false) {
 			throw new RuntimeException('Could not reach node runtime');
 		}

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -75,7 +75,7 @@ class Autoprefixer
 			throw new AutoprefixerException("Error log file '$error_log_file' isn't writable");
 		}
 
-		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
+		$nodejs = proc_open((defined('NODE_PATH') ? NODE_PATH : 'node') . ' ' . __DIR__ . '/vendor/wrap.js',
 			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file, 'a')),
 			$pipes
 		);

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -65,15 +65,18 @@ class Autoprefixer
 			throw new AutoprefixerException($error_message);
 		}
 
-        // by default, use OS temp dir
-        $error_log_file_path = defined('AF_LOG_PATH') ? AF_LOG_PATH : (sys_get_temp_dir() . '/autoprefixer.error.log');
-
-        if (!is_writable($error_log_file_path)){
-            throw new AutoprefixerException("Error log file $error_log_file_path isn't writable");
-        }
+		// by default, use OS temp dir
+		$error_log_dir = defined('AF_LOG_DIR') ? AF_LOG_DIR : sys_get_temp_dir();
+		$error_log_file = $error_log_dir . DIRECTORY_SEPARATOR . 'autoprefixer.error.log';
+		if (!file_exists($error_log_file)) {
+			@touch($error_log_file);
+		}
+		if (!is_writable($error_log_file)){
+			throw new AutoprefixerException("Error log file '$error_log_file' isn't writable");
+		}
 
 		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
-			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file_path, 'a')),
+			array(array('pipe', 'r'), array('pipe', 'w'), array('file', $error_log_file, 'a')),
 			$pipes
 		);
 

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -64,7 +64,7 @@ class Autoprefixer
         }
 
         $nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
-            array(array('pipe', 'r'), array('pipe', 'w')),
+			array(array('pipe', 'r'), array('pipe', 'w'), array('file', '/tmp/autoprefixer.error.log', 'a')),
             $pipes
         );
         if ($nodejs === false) {

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -48,14 +48,6 @@ class Autoprefixer
             $css = array($css);
         }
         
-        $nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
-            array(array('pipe', 'r'), array('pipe', 'w')),
-            $pipes
-        );
-        if ($nodejs === false) {
-            throw new RuntimeException('Could not reach node runtime');
-        }
-
         $data_string = json_encode(array(
             'css' => $css,
             'browsers' => !is_null($browsers) ? $browsers : $this->browsers)
@@ -69,6 +61,14 @@ class Autoprefixer
                 $error_message .= json_last_error();
             }
             throw new AutoprefixerException($error_message);
+        }
+
+        $nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
+            array(array('pipe', 'r'), array('pipe', 'w')),
+            $pipes
+        );
+        if ($nodejs === false) {
+            throw new RuntimeException('Could not reach node runtime');
         }
 
         $this->fwrite_stream($pipes[0], $data_string);

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -56,11 +56,22 @@ class Autoprefixer
             throw new RuntimeException('Could not reach node runtime');
         }
 
-        $this->fwrite_stream($pipes[0],
-            json_encode(array(
-                'css' => $css,
-                'browsers' => !is_null($browsers) ? $browsers : $this->browsers)
-            ));
+        $data_string = json_encode(array(
+            'css' => $css,
+            'browsers' => !is_null($browsers) ? $browsers : $this->browsers)
+        );
+
+        if($data_string === false || $data_string === null) {
+            $error_message = 'Failed to json_encode: ';
+            if (function_exists('json_last_error_msg')) {
+                $error_message .= json_last_error_msg();
+            } else {
+                $error_message .= json_last_error();
+            }
+            throw new AutoprefixerException($error_message);
+        }
+
+        $this->fwrite_stream($pipes[0], $data_string);
         fclose($pipes[0]);
 
         $output = stream_get_contents($pipes[1]);

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -7,127 +7,141 @@
 
 class Autoprefixer
 {
-    /**
-     * @var array
-     */
-    private $browsers = array();
-    
-    /**
-     * @param   mixed   $browsers
-     */
-    public function __construct($browsers = null)
-    {
-        if (!is_null($browsers)) {
-            $this->setBrowsers($browsers);
-        }
-    }
-    
-    /**
-     * Set browsers info.
-     * @param   mixed   $browsers   String if one argument, array if many.
-     * @return  void
-     */
-    public function setBrowsers($browsers)
-    {
-        if (!is_array($browsers)) {
-            $browsers = array($browsers);
-        }
-        $this->browsers = $browsers;
-    }
+	/**
+	 * @var array
+	 */
+	private $browsers = array();
 
-    /**
-     * @param   mixed   $css
-     * @param   mixed   $browsers
-     * @throws  RuntimeException        If node runtime unavailable
-     * @throws  AutoprefixerException
-     * @return  array
-     */
-    public function compile($css, $browsers = null)
-    {
+	/**
+	 * @param   mixed   $browsers
+	 */
+	public function __construct($browsers = null)
+	{
+		if (!is_null($browsers)) {
+			$this->setBrowsers($browsers);
+		}
+	}
+
+	/**
+	 * Set browsers info.
+	 * @param   mixed   $browsers   String if one argument, array if many.
+	 * @return  void
+	 */
+	public function setBrowsers($browsers)
+	{
+		if (!is_array($browsers)) {
+			$browsers = array($browsers);
+		}
+		$this->browsers = $browsers;
+	}
+
+	/**
+	 * @param   mixed   $css
+	 * @param   mixed   $browsers
+	 * @throws  RuntimeException        If node runtime unavailable
+	 * @throws  AutoprefixerException
+	 * @return  array
+	 */
+	public function compile($css, $browsers = null)
+	{
         if ($return_string = !is_array($css)) {
-            $css = array($css);
-        }
-        
-        $data_string = json_encode(array(
-            'css' => $css,
+			$css = array($css);
+		}
+
+		$data_string = json_encode(array(
+			'css'      => $css,
             'browsers' => !is_null($browsers) ? $browsers : $this->browsers)
         );
 
-        if($data_string === false || $data_string === null) {
-            $error_message = 'Failed to json_encode: ';
-            if (function_exists('json_last_error_msg')) {
-                $error_message .= json_last_error_msg();
-            } else {
-                $error_message .= json_last_error();
-            }
-            throw new AutoprefixerException($error_message);
-        }
+		if ($data_string === false || $data_string === null) {
+			$error_message = 'Failed to json_encode: ';
+			if (function_exists('json_last_error_msg')) {
+				$error_message .= json_last_error_msg();
+			} else {
+				$error_message .= json_last_error();
+			}
+			throw new AutoprefixerException($error_message);
+		}
 
-        $nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
+		$nodejs = proc_open('node ' . __DIR__ . '/vendor/wrap.js',
 			array(array('pipe', 'r'), array('pipe', 'w'), array('file', '/tmp/autoprefixer.error.log', 'a')),
-            $pipes
-        );
-        if ($nodejs === false) {
-            throw new RuntimeException('Could not reach node runtime');
-        }
+			$pipes
+		);
+		if ($nodejs === false) {
+			throw new RuntimeException('Could not reach node runtime');
+		}
 
-        $this->fwrite_stream($pipes[0], $data_string);
-        fclose($pipes[0]);
+		$written = $this->fwrite_stream($pipes[0], $data_string);
+		fclose($pipes[0]);
 
-        $output = stream_get_contents($pipes[1]);
-        $output = json_decode($output, true);
-        fclose($pipes[1]);
-        
-        proc_close($nodejs);
-        
-        $error_messages = '';
-        foreach ($output as $key => &$value) {
-            if (preg_match('/^Error:\s*/i', $value)) {
-                $value = preg_replace('/^Error:\s*/i', '', $value);
-                $error_messages .= "In css[$key]: $value \n";
-            }
-        }
-        
-        if (strlen($error_messages) > 0) {
-            throw new AutoprefixerException($error_messages);
-        }
-        
-        return $return_string ? $output[0] : $output;
-    }
-    
-    /**
-     * Download autoprefixer updates.
-     * @return  bool    True if updated.
-     */
-    public function update()
-    {
-        $update_url = 'https://raw.github.com/ai/autoprefixer-rails/master/vendor/autoprefixer.js';
-        $local_path = __DIR__ . '/vendor/autoprefixer.js';
-        $new = file_get_contents($update_url);
-        $old = file_get_contents($local_path);
-        
-        if (md5($new) == md5($old)) return false;
-        
-        file_put_contents($local_path, $new);
-        return true;
-    }
-    
-    /**
-     * @param   object  $fp         php://stdin
-     * @param   string  $string
-     * @param   int     $buflen
-     * @return  string
-     */
-    private function fwrite_stream($fp, $string, $buflen = 4096)
-    {
-        for ($written = 0, $len = strlen($string); $written < $len; $written += $fwrite) {
-            $fwrite = fwrite($fp, substr($string, $written, $buflen));
-            if ($fwrite === false) {
-                return $written;
-            }
-        }
-        
-        return $written;
-    }
-    
+		if ($written !== strlen($data_string)) {
+			proc_close($nodejs);
+			throw new AutoprefixerException(sprintf('Could not write data: %d/%d', $written, strlen($data_string)));
+		}
+
+		$output = stream_get_contents($pipes[1]);
+		proc_close($nodejs);
+
+		if (!$output) {
+			// $stat = proc_get_status($nodejs);
+			// ini_set( 'xdebug.overload_var_dump', 'off' );
+			// var_dump($output, $stat);exit;
+			throw new AutoprefixerException('Could not read output');
+		}
+		$output = json_decode($output, true);
+
+		if (!is_array($output)) {
+			throw new AutoprefixerException('Broken output');
+		}
+
+		$error_messages = '';
+		foreach ($output as $key => &$value) {
+			if (preg_match('/^Error:\s*/i', $value)) {
+				$value = preg_replace('/^Error:\s*/i', '', $value);
+				$error_messages .= "In css[$key]: $value \n";
+			}
+		}
+
+		if (strlen($error_messages) > 0) {
+			throw new AutoprefixerException($error_messages);
+		}
+
+		return $return_string ? $output[0] : $output;
+	}
+
+	/**
+	 * Download autoprefixer updates.
+	 * @return  bool    True if updated.
+	 */
+	public function update()
+	{
+		$update_url = 'https://raw.github.com/ai/autoprefixer-rails/master/vendor/autoprefixer.js';
+		$local_path = __DIR__ . '/vendor/autoprefixer.js';
+		$new = file_get_contents($update_url);
+		$old = file_get_contents($local_path);
+
+		if (md5($new) == md5($old)) return false;
+
+		file_put_contents($local_path, $new);
+		return true;
+	}
+
+	/**
+	 * @param   object  $fp         php://stdin
+	 * @param   string  $string
+	 * @param   int     $buflen
+	 * @return  string
+	 */
+	private function fwrite_stream($fp, $string, $buflen = 4096)
+	{
+		for ($written = 0, $len = strlen($string); $written < $len; $written += $fwrite) {
+			$fwrite = fwrite($fp, substr($string, $written, $buflen));
+			if ($fwrite === false) {
+				return $written;
+			}
+		}
+
+		return $written;
+	}
+
 };

--- a/lib/Autoprefixer.php
+++ b/lib/Autoprefixer.php
@@ -73,10 +73,6 @@ class Autoprefixer
 			throw new RuntimeException('Could not reach node runtime');
 		}
 
-		// Make stdin/stdout non-blocking
-		// stream_set_blocking($pipes[0], 0);
-		// stream_set_blocking($pipes[1], 0);
-
 		$written = $this->fwrite_stream($pipes[0], $data_string);
 		fclose($pipes[0]);
 
@@ -89,9 +85,6 @@ class Autoprefixer
 		proc_close($nodejs);
 
 		if (!$output) {
-			// $stat = proc_get_status($nodejs);
-			// ini_set( 'xdebug.overload_var_dump', 'off' );
-			// var_dump($output, $stat);exit;
 			throw new AutoprefixerException('Could not read output');
 		}
 		$output = json_decode($output, true);

--- a/test/AutoprefixerTest.php
+++ b/test/AutoprefixerTest.php
@@ -72,7 +72,13 @@ class AutoprefixerTest extends PHPUnit_Framework_TestCase
             }
         }
         
-        $input  = $this->clear($this->autoprefixer->compile($input, $browsers));
+        try {
+            $input = $this->autoprefixer->compile($input, $browsers);
+        } catch (AutoprefixerException $e) {
+            $output = $input;
+        }
+        
+        $input  = $this->clear($input);
         $output = $this->clear($output);
         
         static::$tests[$name] = array($input, $output);

--- a/test/cases/utf8.css
+++ b/test/cases/utf8.css
@@ -1,0 +1,3 @@
+.comment:before{
+	content: '“';
+}

--- a/test/cases/utf8_broken.css
+++ b/test/cases/utf8_broken.css
@@ -1,0 +1,3 @@
+.square:after {
+	content: ' ft²';
+}


### PR DESCRIPTION
[test.css.txt](https://github.com/vladkens/autoprefixer-php/files/1649365/test.css.txt)
Catch `json_encode` errors, like `Malformed UTF-8 characters, possibly incorrectly encoded` (e.g. broken encoding in `content` CSS rule, example attached)

Without checking if `json_encode` ran successfully further execution logic breaks e.g. `$output` will be `false`, and `foreach` will trigger `E_WARNING` level error

